### PR TITLE
Named the vagrant instances/vm iso's 

### DIFF
--- a/vagrant/centos6.6/build-and-deploy-box/Vagrantfile
+++ b/vagrant/centos6.6/build-and-deploy-box/Vagrantfile
@@ -12,6 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "chef/centos-6.6"
+  config.vm.define "ozp-centos6.6"
 
   # provision
   config.vm.provision :shell, path: "bootstrap.sh", privileged: false
@@ -57,9 +58,10 @@ Vagrant.configure(2) do |config|
   # Example for VirtualBox:
   #
   config.vm.provider "virtualbox" do |vb|
+  #   # Name the box something useful.
+      vb.name = "ozp-centos6.6"
   #   # Don't boot with headless mode
   #   vb.gui = true
-  #
   #   # Use VBoxManage to customize the VM. For example to change memory:
   #   vb.customize ["modifyvm", :id, "--memory", "1024"]
     vb.customize ["modifyvm", :id, "--memory", "2048"]

--- a/vagrant/centos6.6/build-and-deploy-box/dev-scripts/apps-prebuilt-redeploy.sh
+++ b/vagrant/centos6.6/build-and-deploy-box/dev-scripts/apps-prebuilt-redeploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Use case: developer working on ozp-iwc on host box, building on host box,
-# needs to redeploy pre-built IWC updates on VM.
+# Use case: developer working on demo-apps on host box, building on host box,
+# needs to redeploy app updates on VM.
 
 # Assumes code on host lives
 # in ~/ozp/ozp-iwc (modify the Vagrantfile if ~/ozp is not where you want
@@ -22,18 +22,15 @@ RSYNC_DIR=${HOMEDIR}/ozp
 
 
 # remove old build deployment
-sudo rm -rf ${STATIC_DEPLOY_DIR}/iwc/*
+sudo rm -rf ${STATIC_DEPLOY_DIR}/demo_apps/*
 # copy pre-built iwc to the deployment directory
-sudo cp -r ${RSYNC_DIR}/ozp-iwc/dist/* ${STATIC_DEPLOY_DIR}/iwc
-sudo cp -r ${RSYNC_DIR}/ozp-iwc/dist/* ${STATIC_DEPLOY_DIR}/demo_apps/bower_components/ozp-iwc/dist
+sudo cp -r ${RSYNC_DIR}/ozp-demo/app/* ${STATIC_DEPLOY_DIR}/demo_apps
 
-# IWC configurations
-sudo sed -i "0,/\(ozpIwc\.apiRootUrl=\).*/s//\1'https:\/\/${HOST_IP}:7799\/marketplace\/api'/" ${STATIC_DEPLOY_DIR}/iwc/iframe_peer.html
-sudo sed -i "0,/\(ozpIwc\.apiRootUrl=\).*/s//\1'https:\/\/${HOST_IP}:7799\/marketplace\/api'/" ${STATIC_DEPLOY_DIR}/iwc/intentsChooser.html
-sudo sed -i "0,/\(ozpIwc\.apiRootUrl=\).*/s//\1'https:\/\/${HOST_IP}:7799\/marketplace\/api'/" ${STATIC_DEPLOY_DIR}/iwc/debugger.html
-
+# App configurations
+sudo sed -i "0,/\(iwcUrl:\).*/s//\1\"https:\/\/${HOST_IP}:7799\/iwc\"/" ${STATIC_DEPLOY_DIR}/demo_apps/OzoneConfig.js
 
 # fix ownership and restart nginx
 sudo chown -R nginx ${STATIC_DEPLOY_DIR}
 sudo service nginx restart
 printf "\n****************\n  Finished IWC re-deploy \n****************\n"
+

--- a/vagrant/centos6.6/build-and-deploy-box/dev-scripts/legacy-adapter-prebuilt-redeploy.sh
+++ b/vagrant/centos6.6/build-and-deploy-box/dev-scripts/legacy-adapter-prebuilt-redeploy.sh
@@ -26,7 +26,7 @@ sudo rm -rf ${STATIC_DEPLOY_DIR}/iwc-owf7-widget-adapter/*
 
 # copy pre-built adapter to the deployment directory
 sudo cp -r ${RSYNC_DIR}/ozp-iwc-owf7-widget-adapter/dist/* ${STATIC_DEPLOY_DIR}/iwc/
-
+sudo cp -r ${RSYNC_DIR}/ozp-iwc-owf7-widget-adapter/dist/* ${STATIC_DEPLOY_DIR}/demo_apps/bower_components/ozp-iwc/dist
 # fix ownership and restart nginx
 sudo chown -R nginx ${STATIC_DEPLOY_DIR}
 sudo service nginx restart

--- a/vagrant/centos6.6/build-and-deploy-box/dev-sync-and-run.sh
+++ b/vagrant/centos6.6/build-and-deploy-box/dev-sync-and-run.sh
@@ -14,3 +14,11 @@ vagrant rsync
 
 # change the script invoked here based on your own needs
 vagrant ssh -c "/vagrant/dev-scripts/backend-rebuild-redeploy.sh"
+
+#Front end
+# Apps copied first
+vagrant ssh -c "/vagrant/dev-scripts/apps-prebuilt-redeploy.sh"
+# Then IWC is added both to static and bower dependencies
+vagrant ssh -c "/vagrant/dev-scripts/iwc-prebuilt-redeploy.sh"
+# Legacy adapter is added wherever IWC is added
+vagrant ssh -c "/vagrant/dev-scripts/legacy-adapter-prebuilt-redeploy.sh"

--- a/vagrant/ubuntu14.4/build-and-deploy-box/Vagrantfile
+++ b/vagrant/ubuntu14.4/build-and-deploy-box/Vagrantfile
@@ -12,6 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "ubuntu/trusty64"
+  config.vm.define "ozp-ubuntu14.4"
 
   # provision
   config.vm.provision :shell, path: "bootstrap.sh", privileged: false
@@ -64,6 +65,8 @@ Vagrant.configure(2) do |config|
   # Example for VirtualBox:
   #
   config.vm.provider "virtualbox" do |vb|
+  #   # Name the box something useful.
+      vb.name = "ozp-ubuntu14.4"
   #   # Don't boot with headless mode
   #   vb.gui = true
   #


### PR DESCRIPTION
so that default & build-and-deploy_XXXX-XXXX.iso aren't used respectively.

This makes maintaining the VM's easier. each vagrant configuration is named following the `ozp-<os>` format. Also this makes monitoring vagrant easier as log's won't show tagged with `default` rather the specific os type being ran.

## Note
With this change vagrant will be looking for `.vagrant/machines/ozp-<os>` rather than `.vagrant/machines/default`.

**This will cause `vagrant status` to produce an output like so**:
```
vagrant status
Current machine states:

default                   not created (virtualbox)

The environment has not yet been created. Run `vagrant up` to
create the environment. If a machine is not created, only the
default provider will be shown. So if a provider is not listed,
then the machine is not created for that environment.
```
*This will cause your vagrant to no longer notice your previously built instance prior to this commit.* Fear not this is not an unexpected behavior and to prevent vagrant from instantiating a new box simply rename your vagrant machine directory accordingly. See example below.

### centos6.6
``` 
cd dev-tools/vagrant/centos6.6/build-and-deploy-box/.vagrant/machines
```
``` 
ls -al default/virtualbox
```

Is there anything `default/virtualbox` directory?
* **no**: Your vagrant machine hasn't been setup yet. **You do not need to follow these steps**, continue with your vagrant setup. The machine will be named properly.
* **yes**: Your vagrant machine is set up but named `default`, it needs to be renamed to the new naming convention. 

``` 
mv default ozp-centos6.6
 ```

Return to the vagrant directory `dev-tools/vagrant/centos6.6/build-and-deploy-box`
With the directory renamed vagrant should be able to recognize the box.

``` 
vagrant status
 ```

Should have an output like this (looking to see that it is no longer in a `not created` state):

```
Current machine states:

ozp-centos6.6             running (virtualbox)

The VM is running. To stop this VM, you can run `vagrant halt` to
shut it down forcefully, or you can run `vagrant suspend` to simply
suspend the virtual machine. In either case, to restart it again,
simply run `vagrant up`.
```


### ubuntu14.4
``` 
cd dev-tools/vagrant/ubuntu14.4/build-and-deploy-box/.vagrant/machines
```
``` 
ls -al default/virtualbox
```

Is there anything `default/virtualbox` directory?
* **no**: Your vagrant machine hasn't been setup yet. **You do not need to follow these steps**, continue with your vagrant setup. The machine will be named properly.
* **yes**: Your vagrant machine is set up but named `default`, it needs to be renamed to the new naming convention. 

``` 
mv default ozp-ubuntu14.4
 ```

Return to the vagrant directory `dev-tools/vagrant/ubuntu14.4/build-and-deploy-box`
With the directory renamed vagrant should be able to recognize the box.

``` 
vagrant status
 ```

Should have an output like this (looking to see that it is no longer in a `not created` state):

```
Current machine states:

ozp-ubuntu14.4             running (virtualbox)

The VM is running. To stop this VM, you can run `vagrant halt` to
shut it down forcefully, or you can run `vagrant suspend` to simply
suspend the virtual machine. In either case, to restart it again,
simply run `vagrant up`.
```