### PR TITLE
Use nvm to configure Node and dependencies

### DIFF
--- a/vagrant/centos6.6/build-and-deploy-box/build.sh
+++ b/vagrant/centos6.6/build-and-deploy-box/build.sh
@@ -39,6 +39,9 @@ printf "\n**************\n  finished cloning front-end repos \n*************\n"
 # http://stackoverflow.com/questions/22387857/stop-bower-from-asking-for-statistics-when-installing
 export CI=true
 
+source ${HOMEDIR}/.nvm/nvm.sh
+nvm use default
+
 # - - - - - - - - - - - - - - - - - - -
 # 				Webtop
 # - - - - - - - - - - - - - - - - - - -

--- a/vagrant/centos6.6/build-and-deploy-box/deploy.sh
+++ b/vagrant/centos6.6/build-and-deploy-box/deploy.sh
@@ -57,6 +57,9 @@ sed -i "s/http:\/\/ozone-development.github.io\/ozp-demo/https:\/\/${HOST_IP}:77
 sed -i "s/http:\/\/ozone-development.github.io\/iwc\/owf7adapter.html?url=http%3A%2F%2Fozone-development.github.io%2Fozp-demo/https:\/\/${HOST_IP}:7799\/iwc\/owf7adapter.html?url=https%3A%2F%2F${HOST_IP}%3A7799%2Fdemo_apps/g" postman/data/modifiedListingData.json
 printf "Sleeping for 2 minutes waiting for server to start"
 sleep 2m
+
+source ${HOMEDIR}/.nvm/nvm.sh
+nvm use default
 newman -k -c postman/createSampleMetaData.json -e postman/env/localDev.json
 newman -k -c postman/createSampleListings.json -e postman/env/localDev.json -n 34 -d postman/data/modifiedListingData.json
 printf "\n*****************\n  Finished deploying backend \n*****************\n"

--- a/vagrant/centos6.6/build-and-deploy-box/dev-scripts/test-center-branch.sh
+++ b/vagrant/centos6.6/build-and-deploy-box/dev-scripts/test-center-branch.sh
@@ -35,6 +35,8 @@ git checkout ${BRANCH_NAME} | tee -a ${OUTPUT_FILE}
 export CI=true
 rm -rf node_modules
 rm -rf bower_components
+source ${HOMEDIR}/.nvm/nvm.sh
+nvm use default
 npm install | tee -a ${OUTPUT_FILE}
 bower install | tee -a ${OUTPUT_FILE}
 npm run build | tee -a ${OUTPUT_FILE}

--- a/vagrant/centos6.6/build-and-deploy-box/dev-scripts/webtop-rebuild-redeploy.sh
+++ b/vagrant/centos6.6/build-and-deploy-box/dev-scripts/webtop-rebuild-redeploy.sh
@@ -30,6 +30,8 @@ export CI=true
 cd ${RSYNC_DIR}/ozp-webtop
 rm -rf node_modules
 rm -rf vendor
+source ${HOMEDIR}/.nvm/nvm.sh
+nvm use default
 npm install
 bower install
 npm run build

--- a/vagrant/centos6.6/build-and-deploy-box/initial_provisioning.sh
+++ b/vagrant/centos6.6/build-and-deploy-box/initial_provisioning.sh
@@ -15,7 +15,11 @@ sudo yum install kernel-headers kernel-devel -y
 printf "\n*************\n finished installing kernel headers \n*************\n"
 sudo yum install java-1.7.0-openjdk java-1.7.0-openjdk-devel git unzip vim -y
 printf "\n**************\n finished installing java and such \n**************\n"
-sudo yum install nodejs npm -y
+sudo yum install gcc-c++ -y
+curl -s https://raw.githubusercontent.com/creationix/nvm/v0.30.1/install.sh | bash
+source ${HOMEDIR}/.nvm/nvm.sh
+nvm install 0.12
+nvm alias default node
 printf "\n**************\nfinished installing nodejs and npm\n**************\n"
 # install gvm
 curl -s get.gvmtool.net | bash

--- a/vagrant/centos6.6/build-and-deploy-box/initial_provisioning.sh
+++ b/vagrant/centos6.6/build-and-deploy-box/initial_provisioning.sh
@@ -76,7 +76,7 @@ sudo yum remove mysql mysql-* -y
 sudo yum --enablerepo=remi,remi-test install mysql mysql-server tomcat elasticsearch nginx multitail -y
 
 # Install newman (for adding test data)
-sudo npm install -g newman bower
+npm install -g newman bower
 
 printf "\n***************\nfinished deployment installation\n***************\n"
 


### PR DESCRIPTION
Much like gvmtool/sdkman are used to configure grails, nvm can be used to configure node. As written, this upgrades node from the current yum repo version (v0.10 at the moment) to v0.12. This should fix #15, and prevent similar errors from occurring again.